### PR TITLE
Updates and improvements

### DIFF
--- a/Django.xml
+++ b/Django.xml
@@ -40,4 +40,36 @@
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context />
   </template>
+  <template name="for" value="{% for $VAR$ in $VAR2$ %}&#10;    $SELECTION$$END$&#10;{% endfor %}" description="Django template for loop" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="''" alwaysStopAt="true" />
+    <variable name="VAR2" expression="" defaultValue="''" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
+  <template name="forelse" value="{% for $VAR$ in $VAR2$ %}&#10;    $SELECTION$$END$&#10;{% empty %}&#10;    &#10;{% endfor %}" description="Django template for-empty loop" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="''" alwaysStopAt="true" />
+    <variable name="VAR2" expression="" defaultValue="''" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
+  <template name="block" value="{% block $BLOCK$ %}$END${% endblock %}" description="Django template block" toReformat="false" toShortenFQNames="true">
+    <variable name="BLOCK" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
+  <template name="ifelse" value="{% if $VAR$ %}&#10;    $SELECTION$$END$&#10;{% else %}&#10;    $SELECTION$&#10;{% endif %}" description="Django template if/else statement" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
+  <template name="if" value="{% if $VAR$ %}&#10;    $SELECTION$$END$    &#10;{% endif %}" description="Django template if statement" toReformat="false" toShortenFQNames="true">
+    <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
 </templateSet>

--- a/Django.xml
+++ b/Django.xml
@@ -1,7 +1,9 @@
 <templateSet group="Django">
   <template name="trans" value="{% trans '$VAL$' %}" description="" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="url" value="{% url '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
@@ -11,21 +13,31 @@
   </template>
   <template name="include" value="{% include '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="comment" value="{% comment %}$VAL${% endcomment %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="csrf" value="{% csrf_token %}" toReformat="false" toShortenFQNames="true">
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="debug" value="{% debug %}" toReformat="false" toShortenFQNames="true">
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="extends" value="{% extends '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="tag" value="{% $VAL$ %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
@@ -34,11 +46,15 @@
     </context>
   </template>
   <template name="else" value="{% else %}" toReformat="false" toShortenFQNames="true">
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="static" value="{% static '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
   </template>
   <template name="for" value="{% for $VAR$ in $VAR2$ %}&#10;    $SELECTION$$END$&#10;{% endfor %}" description="Django template for loop" toReformat="false" toShortenFQNames="true">
     <variable name="VAR" expression="" defaultValue="''" alwaysStopAt="true" />

--- a/Django.xml
+++ b/Django.xml
@@ -1,56 +1,56 @@
 <templateSet group="Django">
-  <template name="trans" value="{% trans '$VAL$' %}" description="" toReformat="false" toShortenFQNames="true">
+  <template name="trans" value="{% trans '$VAL$' %}" description="Django template trans tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="url" value="{% url '$VAL$' %}" toReformat="false" toShortenFQNames="true">
+  <template name="url" value="{% url '$VAL$' %}" description="Django template url tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="include" value="{% include '$VAL$' %}" toReformat="false" toShortenFQNames="true">
+  <template name="include" value="{% include '$VAL$' %}" description="Django template include tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="comment" value="{% comment %}$VAL${% endcomment %}" toReformat="false" toShortenFQNames="true">
+  <template name="comment" value="{% comment %}$VAL${% endcomment %}" description="Django template comment" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="csrf" value="{% csrf_token %}" toReformat="false" toShortenFQNames="true">
+  <template name="csrf" value="{% csrf_token %}" description="Django template CSRF token" toReformat="false" toShortenFQNames="true">
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="debug" value="{% debug %}" toReformat="false" toShortenFQNames="true">
+  <template name="debug" value="{% debug %}" description="Django template debug tag" toReformat="false" toShortenFQNames="true">
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="extends" value="{% extends '$VAL$' %}" toReformat="false" toShortenFQNames="true">
+  <template name="extends" value="{% extends '$VAL$' %}" description="Django template extends tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="tag" value="{% $VAL$ %}" toReformat="false" toShortenFQNames="true">
+  <template name="tag" value="{% $VAL$ %}" description="Django template tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="else" value="{% else %}" toReformat="false" toShortenFQNames="true">
+  <template name="else" value="{% else %}" description="Django template else tag" toReformat="false" toShortenFQNames="true">
     <context>
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="static" value="{% static '$VAL$' %}" toReformat="false" toShortenFQNames="true">
+  <template name="static" value="{% static '$VAL$' %}" description="Django template static tag" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />

--- a/Django.xml
+++ b/Django.xml
@@ -1,63 +1,43 @@
 <templateSet group="Django">
-  <template name="trans" value="{% trans &quot;$VAL$&quot; %}" description="" toReformat="false" toShortenFQNames="true">
+  <template name="trans" value="{% trans '$VAL$' %}" description="" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
-  <template name="url" value="{% url &quot;$VAL$&quot; %}" toReformat="false" toShortenFQNames="true">
+  <template name="url" value="{% url '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML_TEXT" value="true" />
       <option name="HTML" value="true" />
-      <option name="Django" value="true" />
     </context>
   </template>
-  <template name="include" value="{% include &quot;$VAL$&quot; %}" toReformat="false" toShortenFQNames="true">
+  <template name="include" value="{% include '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
   <template name="comment" value="{% comment %}$VAL${% endcomment %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
   <template name="csrf" value="{% csrf_token %}" toReformat="false" toShortenFQNames="true">
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
   <template name="debug" value="{% debug %}" toReformat="false" toShortenFQNames="true">
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
-  <template name="extends" value="{% extends &quot;$VAL$&quot; %}" toReformat="false" toShortenFQNames="true">
+  <template name="extends" value="{% extends '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
   <template name="tag" value="{% $VAL$ %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML_TEXT" value="true" />
       <option name="HTML" value="true" />
-      <option name="Django" value="true" />
     </context>
   </template>
   <template name="else" value="{% else %}" toReformat="false" toShortenFQNames="true">
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
-  <template name="static" value="{% static &quot;$VAL$&quot; %}" toReformat="false" toShortenFQNames="true">
+  <template name="static" value="{% static '$VAL$' %}" toReformat="false" toShortenFQNames="true">
     <variable name="VAL" expression="" defaultValue="" alwaysStopAt="true" />
-    <context>
-      <option name="Django" value="true" />
-    </context>
+    <context />
   </template>
 </templateSet>


### PR DESCRIPTION
I don't know if PyCharm changed their desired format or if there's something missing in the original repo, but here's an update reflecting what my current version (PyCharm CE 2016.2.3) thinks the live template XML format should be.  
I also added a few new templates for if, ifelse, for, forelse (should've been called forempty...) and block, for inserting the corresponding {% tags %}.  
Logically, ifelse will insert:

```
{% if <first cursor position> %}
    <selection><final cursor position>
{% else %}
    <selection>
{% endif %}
```

And the others follow a similar pattern.